### PR TITLE
[Fix] : 탭바 내의 뷰가 safe area를 무시하는 현상 수정

### DIFF
--- a/PoorGuys/Views/CustomTabBar/CustomTabBarContainerView.swift
+++ b/PoorGuys/Views/CustomTabBar/CustomTabBarContainerView.swift
@@ -19,7 +19,7 @@ struct CustomTabBarContainerView<Content: View>: View {
     
     var body: some View {
         ZStack() {
-            content.ignoresSafeArea()
+            content
             VStack {
                 Spacer()
                 CustomTabBarView(tabs: tabs, selection: $selection, localSelection: selection)

--- a/PoorGuys/Views/CustomTabBar/CustomTabBarView.swift
+++ b/PoorGuys/Views/CustomTabBar/CustomTabBarView.swift
@@ -31,7 +31,6 @@ enum TabBarItem: Hashable {
 struct CustomTabBarView: View {
     let tabs: [TabBarItem]
     @Binding var selection: TabBarItem
-    @Namespace private var namespace
     @State var localSelection: TabBarItem
     
     var body: some View {


### PR DESCRIPTION
## 개요
탭바 내에 적용된 뷰가 아래 사진과 같이 safe area를 무시하는 현상을 수정하였습니다.

<img src="https://github.com/BeHealthy3/PoorGuys/assets/22342277/01a87fe7-6bc4-435f-92c1-9448a08f2f3b" width="300">

## 작업사항

탭 바 내의 content를 보여주는 부분에서 ignoreSafeArea가 적용된 것을 수정하여 safe area를 무시하지 않도록 변경했습니다.

<img src="https://github.com/BeHealthy3/PoorGuys/assets/22342277/07b8f271-8521-4330-a3dd-518e5a116ed2" width="300">

## 변경로직

CustomTabBarContainerView의 22번째 라인을 아래와 같이 변경하였습니다.
```swift
// from
content.ignoreSafeArea()
```

```swift
// to
content
```
