### PR TITLE
[fix] : 프로필 사진 설정 이전에 앱을 종료하면 그 후 정상작동하지 않는 오류 수정

### DIFF
--- a/PoorGuys/ViewModels/Login/LoginViewModel.swift
+++ b/PoorGuys/ViewModels/Login/LoginViewModel.swift
@@ -20,6 +20,7 @@ enum SignInState {
 enum LoginError: Error {
     case noCurrentUser
     case noNickName
+    case noProfileImageURL
     case authResultNil
 }
 
@@ -127,7 +128,7 @@ final class LoginViewModel: ObservableObject {
                 // MARK: - 유저 firestore 추가
                 db.collection("users").document(uid).setData([
                     "nickName" : "",
-                    "profileImageURL" : "" // TODO : 기본 프로필 이미지 URL 넣기
+                    "profileImageURL" : "gs://poorguys-ad187.appspot.com/profile_images/default_profile_image"
                 ]) { error in
                     if let error = error {
                         /* TODO : 유저 등록 중 오류가 났을 때 앱에서 어떤 동작을 취해주어야 할까? */
@@ -207,7 +208,15 @@ final class LoginViewModel: ObservableObject {
                     
                     if let _profileImageURL = document.get("profileImageURL") as? String {
                         profileImageURL = _profileImageURL
-                        URLSession.shared.dataTask(with: URL(string: profileImageURL!)!) { data, response, error in
+                        guard let profileImageURL = profileImageURL else {
+                            completion(false, LoginError.noProfileImageURL)
+                            return
+                        }
+                        guard let url = URL(string: profileImageURL) else {
+                            completion(false, LoginError.noProfileImageURL)
+                            return
+                        }
+                        URLSession.shared.dataTask(with: url) { data, response, error in
                             guard let data = data, error == nil else {
                                 completion(false, error)
                                 return


### PR DESCRIPTION
## 개요
 프로필 사진 설정 이전에 앱을 종료하면 그 후 정상작동하지 않는 오류를 수정하였습니다.

## 작업사항
로그인 와중 Firebase Auth에 이전 로그인 기록이 있다면 해당 데이터를 사용해 앱 내부에서 사용할 currentUser 데이터를 채워넣게 됩니다.
이 때 프로필 사진 url이 없는 경우 에러 처리가 완벽하지 않았어서, 프로필 사진을 설정하지 않고 앱을 껏을 경우
구글 로그인은 이미 했기 때문에 이전 로그인 기록은 있지만
프로필 사진 url을 받아올 수 없었기 때문에 오류가 났었습니다. 

이에 따라 프로필 사진 링크를 가져올 수 없거나 프로필 사진 링크가 비어있다면 currentUser 데이터를 채워넣지 않고 로그아웃할 수 있도록 로직을 변경하여 오류를 예방해 보았습니다

## 변경로직
```swift
// before
if let _profileImageURL = document.get("profileImageURL") as? String {
    profileImageURL = _profileImageURL
    URLSession.shared.dataTask(with: URL(string: profileImageURL!)!) { data, response, error in
        guard let data = data, error == nil else {
            completion(false, error)
            return
        }
```
```swift
// after
if let _profileImageURL = document.get("profileImageURL") as? String {
    profileImageURL = _profileImageURL
    guard let profileImageURL = profileImageURL else {
        completion(false, LoginError.noProfileImageURL)
        return
    }
    guard let url = URL(string: profileImageURL) else {
        completion(false, LoginError.noProfileImageURL)
        return
    }
    URLSession.shared.dataTask(with: url) { data, response, error in
        guard let data = data, error == nil else {
            completion(false, error)
            return
        }
```
