### PR TITLE
[feat] : 프로필 버튼 탭 시 MyPageView 나타날 수 있도록 연결

### DIFF
--- a/PoorGuys/Views/Community/CommunityView.swift
+++ b/PoorGuys/Views/Community/CommunityView.swift
@@ -87,13 +87,11 @@ struct CommunityView<ViewModel: CommunityPostsManagable>: View {
                     .foregroundColor(.accentColor)
             }
             
-            Button(action: {
-                
-            }, label: {
+            NavigationLink(destination: MyPageView()) {
                 Image("profile")
                     .imageScale(.large)
                     .foregroundColor(.accentColor)
-            })
+            }
             .padding(EdgeInsets(top: 0, leading: 5, bottom: 0, trailing: 16))
         }
     }


### PR DESCRIPTION
## 개요
커뮤니티 화면에서 마이페이지 버튼 클릭 시 마이페이지 화면으로 이동하는 기능을 추가하였습니다.

## 작업사항
<img src="https://github.com/BeHealthy3/PoorGuys/assets/22342277/fc495ade-21b3-4517-adfd-47a80d959ba8" width=400>

## 변경로직
before: 
```swift
Button(action: {

}, label: {
    Image("profile")
        .imageScale(.large)
        .foregroundColor(.accentColor)
})
```
now: 
```swift
NavigationLink(destination: MyPageView()) {
    Image("profile")
        .imageScale(.large)
        .foregroundColor(.accentColor)
}
```