### PR TITLE
[fix] : 구글 로그인 시 실제 로그인하지 않았음에도 닉네임 입력 창이 나타나는 현상 수정

### DIFF
--- a/PoorGuys/Views/Login/LoginView.swift
+++ b/PoorGuys/Views/Login/LoginView.swift
@@ -36,8 +36,10 @@ struct LoginView: View {
     func googleLoginButton() -> some View {
         Button {
             loginViewModel.signInWithGoogle() { isSignedIn, error in
-                if !loginViewModel.didSetNickName {
-                    self.isPresentingSetNickNameView = true
+                if isSignedIn {
+                    if !loginViewModel.didSetNickName {
+                        self.isPresentingSetNickNameView = true
+                    }
                 }
             }
         } label: {


### PR DESCRIPTION
## 개요
구글 로그인 진행 중 로그인하지 않고 창을 내려도 닉네임 입력 창이 나타나는 현상을 수정하였습니다.

## 작업사항
* 작업 이전 - 창을 내려도 닉네임 입력 창이 나타납니다.
<img src="https://github.com/BeHealthy3/PoorGuys/assets/22342277/a94ddb8d-dba3-42fa-9e7f-a7e3d320b834" width=300>

* 작업 이후 - 창을 내리면 닉네임 창이 나타나지 않습니다.
<img src="https://github.com/BeHealthy3/PoorGuys/assets/22342277/2ba47012-24c1-487c-9b56-6e905f3e46b1" width=300>


## 변경로직
before
```swift
Button {
  loginViewModel.signInWithGoogle() { isSignedIn, error in
    if !loginViewModel.didSetNickName {
        self.isPresentingSetNickNameView = true
    }
  }
```
now
```swift
Button {
  loginViewModel.signInWithGoogle() { isSignedIn, error in
      if isSignedIn {
          if !loginViewModel.didSetNickName {
              self.isPresentingSetNickNameView = true
          }
      }
  }
```
