### PR TITLE
Fix/login error

### DIFF
--- a/PoorGuys/ViewModels/Login/LoginViewModel.swift
+++ b/PoorGuys/ViewModels/Login/LoginViewModel.swift
@@ -124,7 +124,6 @@ final class LoginViewModel: ObservableObject {
                 }
             } else {
                 print("해당하는 유저 없음")
-                completion(false, nil)
                 // MARK: - 유저 firestore 추가
                 db.collection("users").document(uid).setData([
                     "nickName" : "",
@@ -134,9 +133,11 @@ final class LoginViewModel: ObservableObject {
                         /* TODO : 유저 등록 중 오류가 났을 때 앱에서 어떤 동작을 취해주어야 할까? */
                         print("유저 등록 중 오류 : \(error)")
                         self.isUserInFirestore = false
+                        completion(false, error)
                     } else {
                         print("새로운 유저 firestore에 등록 완료")
                         self.isUserInFirestore = true
+                        completion(true, nil)
                     }
                 }
             }

--- a/PoorGuys/Views/Login/LoginView.swift
+++ b/PoorGuys/Views/Login/LoginView.swift
@@ -40,6 +40,9 @@ struct LoginView: View {
                     if !loginViewModel.didSetNickName {
                         self.isPresentingSetNickNameView = true
                     }
+                } else {
+                    print("Error: error while signing in : \(String(describing: error))")
+                    // TODO: 추가적인 에러 처리 필요 (팝업 등)
                 }
             }
         } label: {


### PR DESCRIPTION
## 개요
#18  이슈에 대한 사항을 수정하였습니다.

## 작업사항
구글 로그인 처리 로직에 문제가 있어 변경하였습니다.

*같은 전화번호를 여러 번 사용해서 계정을 생성하기가 불가능해 이해를 돕기 위한 gif를 촬영하지 못했습니다.*

## 변경로직

구글 로그인 결과는 컴플리션 핸들러를 통해 상위 함수로 전달됩니다.
새로운 계정으로 가입하는 경우 제대로 가입되었다면 true를 전달해서 로그인이 잘 되었음을 알려야 하는데, false를 전달하고 있었습니다.
해당 부분을 수정하여 문제를 해결했습니다. 

before
```swift
print("해당하는 유저 없음")
completion(false, nil)        // <- 여기 있던 completion이
// MARK: - 유저 firestore 추가
db.collection("users").document(uid).setData([
    "nickName" : "",
    "profileImageURL" : "gs://poorguys-ad187.appspot.com/profile_images/default_profile_image"
]) { error in
    if let error = error {
        /* TODO : 유저 등록 중 오류가 났을 때 앱에서 어떤 동작을 취해주어야 할까? */
        print("유저 등록 중 오류 : \(error)")
        self.isUserInFirestore = false

    } else {
        print("새로운 유저 firestore에 등록 완료")
        self.isUserInFirestore = true

    }
}

```

after
```swift
print("해당하는 유저 없음")
// MARK: - 유저 firestore 추가
db.collection("users").document(uid).setData([
    "nickName" : "",
    "profileImageURL" : "gs://poorguys-ad187.appspot.com/profile_images/default_profile_image"
]) { error in
    if let error = error {
        /* TODO : 유저 등록 중 오류가 났을 때 앱에서 어떤 동작을 취해주어야 할까? */
        print("유저 등록 중 오류 : \(error)")
        self.isUserInFirestore = false
        completion(false, error)        // <- 여기와
    } else {
        print("새로운 유저 firestore에 등록 완료")
        self.isUserInFirestore = true
        completion(true, nil)        // <- 여기로 옮겨갔습니다.
    }
}
```